### PR TITLE
Add frame time measurement

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,8 +17,12 @@ fn main() {
 
     for _ in 0.. trials {
         let start_ns = clock_ticks::precise_time_ns();
-        for _ in 0..frames {
+        let mut fs = clock_ticks::precise_time_ns();
+        for f in 0..frames {
             display.draw().finish().unwrap();
+            let fd = clock_ticks::precise_time_ns() - fs;
+            println!("Frame #{:3}: {}", f, fd);
+            fs = clock_ticks::precise_time_ns();
         }
 
         let duration_ns = clock_ticks::precise_time_ns() - start_ns;


### PR DESCRIPTION
Just added a bit of code to print out how much time each frame takes. For 60 FPS you should see times close to 16.6 ms (16,600,000 ns). On my machine, I've noticed the first run has a couple frames with very short times at the beginning. Outliers like that, especially at the start should be ignored.
